### PR TITLE
feature: adapt projected volume in any version

### DIFF
--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -40,6 +40,10 @@ const (
 	DefaultContainerdSockAddress = "/run/containerd/containerd.sock"
 	DefaultVersion               = "latest"
 	DefaultTarName               = "kosmos-io.tar.gz"
+	// nolint
+	DefaultServiceAccountName = "default"
+	// nolint
+	DefaultServiceAccountToken = "kosmos.io/service-account.name"
 )
 
 const (

--- a/pkg/utils/k8s.go
+++ b/pkg/utils/k8s.go
@@ -246,7 +246,12 @@ func UpdateSecret(old, new *corev1.Secret) {
 	old.Labels = new.Labels
 	old.Data = new.Data
 	old.StringData = new.StringData
-	old.Type = new.Type
+	// The satoken type of default in a subset group is Opaque
+	if old.Annotations[corev1.ServiceAccountNameKey] == DefaultServiceAccountName {
+		old.Type = corev1.SecretTypeOpaque
+	} else {
+		old.Type = new.Type
+	}
 }
 
 func UpdateUnstructured[T *corev1.ConfigMap | *corev1.Secret](old, new *unstructured.Unstructured, oldObj T, newObj T, update func(old, new T)) (*unstructured.Unstructured, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, Please carefully read the comments in our pull request template.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If you want *faster* PR reviews, Please contact us proactively.
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs 
/kind feature
/kind failing-test
-->

#### What does this PR do?
<!--
Provide a brief description of what this PR does
-->
1. Support the creation of pod when automountServiceAccountToken to false
2. kosmos projected the same for k8s version 1.25 or greater
#### Which issue(s) does this PR fix?
<!--
Reference any relevant issue(s) by using the syntax `Fixes #<issue_number>`, If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #357 
#### Special notes for your reviewer:
<!--
If there's anything specific you'd like your reviewer to pay attention to, mention it here
-->
Test cases:

### **>=1.21 Version && <= 1.23 Version**

1. Mount volume only projected
    1. When automountServiceAccountToken is true
        - If projected is not modified, will the sub-cluster create a permanent `token-secret` and `master-root-ca.crt` certificate?
        - If `default-sa-secret` and `kube-root-ca.crt` contents are modified, will the sub-cluster change accordingly?
        - Define multiple pods, will it create token/cm repeatedly?
    2. When automountServiceAccountToken is false
        - If only satoken is mounted with a custom expirationSeconds set, will the sub-cluster create a permanent `token-secret`?
        - Define multiple projecteds, will they be mounted successfully simultaneously?
        - If multiple secrets, satokens, etc., are defined in one projected, will they be mounted correctly?

2. Mount volume only secret and cm
    1. Mount ordinary secret and cm
    2. Mount token-secret and certificate cm
        - Mount default token-secret and certificate cm, modify secrets and cm, will the sub-cluster synchronize?
        - Mount ordinary secret and cm, modify them, will the sub-cluster synchronize?
        - Mount other token-secrets, will the sub-cluster synchronize?

3. Mount volume with secret, cm, and projected simultaneously
    1. When automountServiceAccountToken is true
        - Mount token and certificate in secrets and cm
        - Mount ordinary secrets and cm
        - Mount other certificates in secrets
    2. When automountServiceAccountToken is false
        - Mount satoken in projected, and mount the same secret in secrets

### **>=1.24 Version**

1. Mount volume only projected
    1. When automountServiceAccountToken is true
        - If projected is not modified, will the sub-cluster create a permanent `token-secret` and `master-root-ca.crt` certificate?
        - If `default-sa-secret` and `kube-root-ca.crt` contents are modified, will the sub-cluster change accordingly?
        - Define multiple pods, will it create token/cm repeatedly?
    2. When automountServiceAccountToken is false
        - If only satoken is mounted with a custom expirationSeconds set, will the sub-cluster create a permanent `token-secret`?
        - Define multiple projecteds, will they be mounted successfully simultaneously?
        - If multiple secrets, satokens, etc., are defined in one projected, will they be mounted correctly?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
