### PR TITLE
fix: status synchronization error of virtual node in one2one model mode

### DIFF
--- a/pkg/clustertree/cluster-manager/utils/leaf_model_handler.go
+++ b/pkg/clustertree/cluster-manager/utils/leaf_model_handler.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -104,6 +105,7 @@ func (h ClassificationHandler) GetLeafPods(ctx context.Context, rootNode *corev1
 
 // UpdateRootNodeStatus updates the node's status in root cluster
 func (h ClassificationHandler) UpdateRootNodeStatus(ctx context.Context, nodesInRoot []*corev1.Node, leafNodeSelector map[string]kosmosv1alpha1.NodeSelector) error {
+	errors := []error{}
 	for _, node := range nodesInRoot {
 		nodeNameInRoot := node.Name
 		listOptions := metav1.ListOptions{}
@@ -114,6 +116,8 @@ func (h ClassificationHandler) UpdateRootNodeStatus(ctx context.Context, nodesIn
 				continue
 			}
 			listOptions.LabelSelector = metav1.FormatLabelSelector(selector.LabelSelector)
+		} else if h.leafMode == Node {
+			listOptions.FieldSelector = fmt.Sprintf("metadata.name=%s", nodeNameInRoot)
 		}
 
 		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -172,10 +176,10 @@ func (h ClassificationHandler) UpdateRootNodeStatus(ctx context.Context, nodesIn
 			return nil
 		})
 		if err != nil {
-			return err
+			errors = append(errors, err)
 		}
 	}
-	return nil
+	return utilerrors.NewAggregate(errors)
 }
 
 func createNode(ctx context.Context, clientset kubernetes.Interface, clusterName, nodeName, gitVersion string, listenPort int32) (*corev1.Node, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, Please carefully read the comments in our pull request template.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If you want *faster* PR reviews, Please contact us proactively.
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs 
/kind feature
/kind failing-test
-->
/kind bug
#### What does this PR do?
<!--
Provide a brief description of what this PR does
-->
When a pipe cluster is configured in one2one mode, the status address of each node is the same
The status of each virtual node is the status of the subset of real nodes in one2one mode
#### Which issue(s) does this PR fix?
<!--
Reference any relevant issue(s) by using the syntax `Fixes #<issue_number>`, If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kosmos-io/kosmos/issues/414
#### Special notes for your reviewer:
<!--
If there's anything specific you'd like your reviewer to pay attention to, mention it here
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
