### PR TITLE
Cherry-Pick: fix instance rescheduler fail by volumeBindingNodeConflict in one2on mode 

### DIFF
--- a/pkg/clustertree/cluster-manager/utils/leaf_model_handler.go
+++ b/pkg/clustertree/cluster-manager/utils/leaf_model_handler.go
@@ -244,6 +244,7 @@ func (h ClassificationHandler) CreateRootNode(ctx context.Context, listenPort in
 	if h.leafMode == ALL {
 		nodeNameInRoot := fmt.Sprintf("%s%s", utils.KosmosNodePrefix, cluster.Name)
 		nodeInRoot, err := createNode(ctx, h.RootClientset, cluster.Name, nodeNameInRoot, gitVersion, listenPort)
+		nodeInRoot.Annotations[nodeMode] = "one2cluster"
 		if err != nil {
 			return nil, nil, err
 		}
@@ -265,6 +266,10 @@ func (h ClassificationHandler) CreateRootNode(ctx context.Context, listenPort in
 			if err != nil {
 				return nil, nil, err
 			}
+			if h.leafMode == Party {
+				nodeInRoot.Annotations[nodeMode] = "one2party"
+			}
+
 			nodes = append(nodes, nodeInRoot)
 			leafNodeSelectors[nodeNameInRoot] = leafModel.NodeSelector
 		}

--- a/pkg/clustertree/cluster-manager/utils/leaf_resource_manager.go
+++ b/pkg/clustertree/cluster-manager/utils/leaf_resource_manager.go
@@ -24,7 +24,8 @@ var (
 type LeafMode int
 
 const (
-	ALL LeafMode = iota
+	nodeMode          = "leafNodeMode"
+	ALL      LeafMode = iota
 	Node
 	Party
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, Please carefully read the comments in our pull request template.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If you want *faster* PR reviews, Please contact us proactively.
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs 
/kind feature
/kind failing-test
-->

#### What does this PR do?
<!--
Provide a brief description of what this PR does
-->
instance rescheduler fail by volumeBindingNodeConflict in one2one mode
#### Which issue(s) does this PR fix?
<!--
Reference any relevant issue(s) by using the syntax `Fixes #<issue_number>`, If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#### Special notes for your reviewer:
<!--
If there's anything specific you'd like your reviewer to pay attention to, mention it here
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```