### PR TITLE
fix: enable switch available during cluster join

### DIFF
--- a/pkg/clusterlink/clusterlink-operator/operator_controller.go
+++ b/pkg/clusterlink/clusterlink-operator/operator_controller.go
@@ -138,7 +138,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	//}
 
 	cluster := &v1alpha1.Cluster{}
-
 	if err := r.Client.Get(ctx, request.NamespacedName, cluster); err != nil {
 		// The resource may no longer exist, in which case we stop processing.
 		if apierrors.IsNotFound(err) {
@@ -152,6 +151,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if len(cluster.GetFinalizers()) == 1 {
 			return r.removeCluster(cluster)
 		}
+	}
+
+	if !cluster.Spec.ClusterLinkOptions.Enable {
+		klog.Infof("cluster %v does not have the clusterlink module enabled, skipping this event.", cluster.Name)
+		return reconcile.Result{}, nil
 	}
 
 	return r.syncCluster(cluster)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, Please carefully read the comments in our pull request template.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If you want *faster* PR reviews, Please contact us proactively.
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs 
/kind feature
/kind failing-test
-->

#### What does this PR do?
<!--
Provide a brief description of what this PR does
-->
Make the clusterlink-operator enable switch available when joining a cluster. 
For example, if you use the command:
$ kosmosctl join cluster --name cluster-c2 --kubeconfig config-c2 --enable-tree
clusterlink-operator will not install clusterlink module services such as clusterlink-agent.

#### Which issue(s) does this PR fix?
<!--
Reference any relevant issue(s) by using the syntax `Fixes #<issue_number>`, If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#### Special notes for your reviewer:
<!--
If there's anything specific you'd like your reviewer to pay attention to, mention it here
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
