### PR TITLE
fix: redundant creation of leaf node

### DIFF
--- a/pkg/clustertree/cluster-manager/cluster_controller.go
+++ b/pkg/clustertree/cluster-manager/cluster_controller.go
@@ -177,6 +177,11 @@ func (c *ClusterController) Reconcile(ctx context.Context, request reconcile.Req
 		return reconcile.Result{}, nil
 	}
 
+	if !cluster.Spec.ClusterTreeOptions.Enable {
+		klog.Infof("Cluster %s does not have the ClusterTree module enabled, skipping this event.", request.Name)
+		return reconcile.Result{}, nil
+	}
+
 	// build mgr for cluster
 	// TODO bug, the v4 log is lost
 	mgr, err := controllerruntime.NewManager(config, controllerruntime.Options{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, Please carefully read the comments in our pull request template.
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added or ran the appropriate tests for your PR.
4. If you want *faster* PR reviews, Please contact us proactively.
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind docs 
/kind feature
/kind failing-test
-->

#### What does this PR do?
<!--
Provide a brief description of what this PR does
-->
If the ClusterTree module is not enabled when joining a cluster, LeafNode should not be created. 
Here is a result of redundantly creating leafNode before optimization: 
```plaintext
kubectl get nodes
NAME                STATUS   ROLES           AGE   VERSION
c3-control-plane    Ready    control-plane   25h   v1.31.0
c3-worker           Ready    <none>          25h   v1.31.0
kosmos-cluster-c2   Ready    agent           14m   v1.31.0
```
Now, if you use the command:
```plaintext
kosmosctl join cluster --name cluster-c2 --cni calico --default-nic eth0 --version v0.5.4 --kubeconfig config-c2 --enable-link
```
, no node with the role of agent will be created.

#### Which issue(s) does this PR fix?
<!--
Reference any relevant issue(s) by using the syntax `Fixes #<issue_number>`, If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#### Special notes for your reviewer:
<!--
If there's anything specific you'd like your reviewer to pay attention to, mention it here
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
